### PR TITLE
Reverting this change as it was fixed independently in the conversion

### DIFF
--- a/static/js/observatory/js/compareViz.js
+++ b/static/js/observatory/js/compareViz.js
@@ -480,13 +480,12 @@ viz file for the comapre visualizations
 		var tooltipsOnLeft = xPos > dimensions.w / 2;
 		tooltips.select('.ttMetric').text(function(d,i) {
 			var dataValue = d.data[xIndex][curMetric.key];
-			var valueTruncated = parseFloat(dataValue).toFixed(curMetric.decimal_digits)
 			var y = i * graphAreaHeight
 
 			d.tooltipX = xPos;
 			d.tooltipY = y + margin.top + yScale(dataValue);
 
-			return valueTruncated + ' ' + curMetric.units
+			return dataValue + ' ' + curMetric.units
 		})
 		tooltips.select('.ttMetricLabel').text(function(d) {
 			return curMetric.name

--- a/static/js/observatory/js/exploreViz.js
+++ b/static/js/observatory/js/exploreViz.js
@@ -512,8 +512,6 @@ viz file for the explore type visualizations
 		var tp = mlabOpenInternet.dataLoader.getTPForCode(code)
 		exploreTT.select('.ttTitle').text(isp + " x " + tp)
 		exploreTT.select('.valueLabel').text(curMetric.name)
-		var truncatedValue = parseFloat(d[curMetric.key]).toFixed(curMetric.decimal_digits)
-		exploreTT.select('.valueValue').text(truncatedValue + " " + curMetric.units)
 		exploreTT.select('.valueValue').text(d[curMetric.key] + " " + curMetric.units)
 		exploreTT.select('.sampleSizeValue').text(d[curMetric.key + '_n'])
 		var momentDate = moment(d.date)

--- a/static/observatory/metadata/metrics.json
+++ b/static/observatory/metadata/metrics.json
@@ -2,31 +2,26 @@
 	{
 		"key": "packet_retransmit_rate",
 		"name": "Packet Retransmit Rate",
-		"units": "%",
-		"decimal_digits": 6
+		"units": "%"
 	},
 	{
 		"key": "minimum_rtt",
 		"name": "Minimum RTT",
-		"units": "ms",
-		"decimal_digits": 1
+		"units": "ms"
 	},
 	{
 		"key": "average_rtt",
 		"name": "Average RTT",
-		"units": "ms",
-		"decimal_digits": 1
+		"units": "ms"
 	},
 	{
 		"key": "download_throughput",
 		"name": "Download Speed",
-		"units": "Mbps",
-		"decimal_digits": 3
+		"units": "Mbps"
 	},
 	{
 		"key": "upload_throughput",
 		"name": "Upload Speed",
-		"units": "Mbps",
-		"decimal_digits": 3
+		"units": "Mbps"
 	}
 ]


### PR DESCRIPTION
script.

Revert "Setting each metric to display values to a specified number of decimal digits"

This reverts commit 769b1608548117a7913d5bcebbb01863b7325d0f.
